### PR TITLE
perf: ページ遷移パフォーマンスを改善

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -171,8 +171,8 @@ const googleAdsenseId = seo.googleAdsenseId || '';
 <meta name="twitter:description" content={truncatedDescription} />
 <meta name="twitter:image" content={new URL(imageSrc, Astro.url)} />
 
-<!-- View Transitions -->
-<ClientRouter />
+<!-- View Transitions (viewport prefetch for faster navigation) -->
+<ClientRouter prefetch="viewport" />
 
 <!-- Dark Mode Detection Script (inline to prevent FOUC) -->
 <script is:inline>

--- a/src/styles/design-tokens.css
+++ b/src/styles/design-tokens.css
@@ -198,6 +198,7 @@
   --duration-normal: 300ms;
   --duration-slow: 500ms;
   --duration-slower: 700ms;
+  --duration-view-transition: 100ms; /* View Transitions専用: 高速なページ遷移体験のため */
 
   --easing-default: cubic-bezier(0.4, 0, 0.2, 1);
   --easing-in: cubic-bezier(0.4, 0, 1, 1);
@@ -407,18 +408,18 @@ html.theme-transitioning *::after {
 
 /* View Transition: ページ全体のフェード */
 ::view-transition-old(root) {
-  animation: var(--duration-normal) var(--easing-out) both fade-out;
+  animation: var(--duration-view-transition) var(--easing-out) both fade-out;
 }
 
 ::view-transition-new(root) {
-  animation: var(--duration-normal) var(--easing-out) both fade-in;
+  animation: var(--duration-view-transition) var(--easing-out) both fade-in;
 }
 
 /* View Transition: メインコンテンツのフェード */
 ::view-transition-old(main-content) {
-  animation: var(--duration-normal) var(--easing-out) both fade-out;
+  animation: var(--duration-view-transition) var(--easing-out) both fade-out;
 }
 
 ::view-transition-new(main-content) {
-  animation: var(--duration-normal) var(--easing-out) both fade-in;
+  animation: var(--duration-view-transition) var(--easing-out) both fade-in;
 }


### PR DESCRIPTION
- ClientRouterにprefetch="viewport"を設定し、ビューポート内のリンクを事前取得
- View Transitionアニメーション時間を300msから100msに短縮（専用変数を追加）

これにより、ブログ一覧ページへの最初のクリック時の遅延が大幅に改善される。