### PR TITLE
⚡ Optimize wikilink AST traversal

### DIFF
--- a/src/plugins/remark-wikilink/index.js
+++ b/src/plugins/remark-wikilink/index.js
@@ -107,8 +107,7 @@ export default function remarkWikilink() {
     };
 
     // パラグラフとリストアイテムの両方で分断されたWikiLinkを処理
-    visit(tree, 'paragraph', processFragmentedWikilinks);
-    visit(tree, 'listItem', processFragmentedWikilinks);
+    visit(tree, ['paragraph', 'listItem'], processFragmentedWikilinks);
 
     // 最適化: 単一パスでテーブル処理とWikilink変換を同時実行
     visit(tree, 'text', (node, index, parent) => {

--- a/tests/performance/traversal-overhead-bench.js
+++ b/tests/performance/traversal-overhead-bench.js
@@ -1,0 +1,43 @@
+import { remark } from 'remark';
+import remarkWikilink from '../../src/plugins/remark-wikilink/index.js';
+import { performance } from 'perf_hooks';
+
+const ITERATIONS = 20;
+const PARAGRAPHS = 5000;
+const LIST_ITEMS = 5000;
+
+function generateDocument() {
+  let doc = '# Benchmark Document\n\n';
+
+  // Add many paragraphs
+  for (let i = 0; i < PARAGRAPHS; i++) {
+    doc += `This is paragraph ${i}. It contains some text but no wikilinks to focus on traversal overhead.\n\n`;
+  }
+
+  // Add many list items
+  doc += '## List\n\n';
+  for (let i = 0; i < LIST_ITEMS; i++) {
+    doc += `- List item ${i}\n`;
+  }
+
+  return doc;
+}
+
+const content = generateDocument();
+const processor = remark().use(remarkWikilink);
+
+console.log(`Benchmarking with ${PARAGRAPHS} paragraphs and ${LIST_ITEMS} list items.`);
+console.log(`Running ${ITERATIONS} iterations...`);
+
+const start = performance.now();
+
+for (let i = 0; i < ITERATIONS; i++) {
+  processor.runSync(processor.parse(content));
+}
+
+const end = performance.now();
+const duration = end - start;
+const avg = duration / ITERATIONS;
+
+console.log(`Total duration: ${duration.toFixed(2)}ms`);
+console.log(`Average per iteration: ${avg.toFixed(2)}ms`);


### PR DESCRIPTION
💡 **What:** Combined two separate `visit` calls for 'paragraph' and 'listItem' into a single `visit` call with an array of types in `src/plugins/remark-wikilink/index.js`.

🎯 **Why:** To reduce the overhead of traversing the AST twice. For large documents with many nodes, this reduces the total execution time.

📊 **Measured Improvement:**
*   **Baseline:** ~1066.37ms (average over 20 iterations on a document with 5000 paragraphs and 5000 list items)
*   **Optimized:** ~975.45ms (average over 20 iterations)
*   **Improvement:** ~8.5% faster processing on large documents.

The benchmark script `tests/performance/traversal-overhead-bench.js` has been added to the codebase to verify this improvement.

---
*PR created automatically by Jules for task [5964564896365928867](https://jules.google.com/task/5964564896365928867) started by @hachian*