### PR TITLE
🔒 Implement Content Security Policy (CSP) in BaseHead

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -85,6 +85,10 @@ const googleAdsenseId = seo.googleAdsenseId || '';
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta
+	http-equiv="Content-Security-Policy"
+	content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://pagead2.googlesyndication.com https://giscus.app; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://giscus.app https://*.google-analytics.com https://stats.g.doubleclick.net; frame-src https://giscus.app https://googleads.g.doubleclick.net https://www.youtube.com; object-src 'none'; base-uri 'self';"
+/>
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="sitemap" href="/sitemap-index.xml" />
 <link

--- a/tests/verify-csp.js
+++ b/tests/verify-csp.js
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const filePath = path.join(__dirname, '../src/components/BaseHead.astro');
+const content = fs.readFileSync(filePath, 'utf8');
+
+// Expected CSP directives
+const expectedDirectives = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://pagead2.googlesyndication.com https://giscus.app",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "img-src 'self' data: https:",
+  "font-src 'self' https://fonts.gstatic.com",
+  "connect-src 'self' https://giscus.app https://*.google-analytics.com https://stats.g.doubleclick.net",
+  "frame-src https://giscus.app https://googleads.g.doubleclick.net https://www.youtube.com",
+  "object-src 'none'",
+  "base-uri 'self'"
+];
+
+// Check for meta tag
+// Modified regex to handle multiline content and surrounding quotes carefully
+const metaTagRegex = /<meta\s+http-equiv="Content-Security-Policy"\s+content="([^"]+)"\s*\/>/;
+// Note: The file content might have newlines if I used git merge diff without collapsing, but let's check.
+// If the content attribute spans lines, the regex `[^"]+` matches newlines too.
+
+const match = content.match(metaTagRegex);
+
+if (!match) {
+  console.error('❌ Content-Security-Policy meta tag not found in BaseHead.astro');
+  // Debug: print file content around where we expect it
+  console.log('File content snippet:');
+  console.log(content.slice(0, 500));
+  process.exit(1);
+}
+
+const cspContent = match[1];
+console.log('✅ Found CSP meta tag:', cspContent);
+
+// Check each directive
+let missingDirectives = [];
+for (const expected of expectedDirectives) {
+  // Normalize whitespace for comparison
+  const normalizedExpected = expected.replace(/\s+/g, ' ').trim();
+  const normalizedContent = cspContent.replace(/\s+/g, ' ').trim();
+
+  if (!normalizedContent.includes(normalizedExpected)) {
+    missingDirectives.push(expected);
+  }
+}
+
+if (missingDirectives.length > 0) {
+  console.error('❌ CSP meta tag is missing expected directives:');
+  missingDirectives.forEach(d => console.error(`   - ${d}`));
+  process.exit(1);
+}
+
+console.log('✅ CSP meta tag contains all expected directives.');
+process.exit(0);


### PR DESCRIPTION
This PR implements a Content Security Policy (CSP) to mitigate XSS and other injection attacks.

### 🎯 What
Added a `<meta http-equiv="Content-Security-Policy">` tag to the `<head>` of the application via `src/components/BaseHead.astro`.

### ⚠️ Risk
Without CSP, the application is vulnerable to Cross-Site Scripting (XSS) attacks where malicious scripts could be injected and executed. This is particularly relevant for a blog template that might render user content (comments) or use third-party integrations.

### 🛡️ Solution
The implemented CSP:
- Restricts default sources to `'self'`.
- Allows necessary external domains for:
    - **Scripts**: Google Tag Manager, AdSense, Giscus.
    - **Styles**: Google Fonts.
    - **Images**: Google Analytics, Giscus (GitHub avatars), and generic HTTPS sources (to support user-configured external image hosting).
    - **Fonts**: Google Fonts (gstatic).
    - **Connections**: Giscus, Google Analytics.
    - **Frames**: Giscus, AdSense, YouTube.
- Sets `object-src 'none'` and `base-uri 'self'` for stricter security.
- Note: `unsafe-inline` is currently permitted for scripts and styles to maintain compatibility with Astro's View Transitions and existing inline scripts (e.g., dark mode toggle) without requiring a significant refactor.

### Verification
A verification script `tests/verify-csp.js` was added and passed, confirming the presence and correctness of the CSP directives.
Full test suite (`npm run test`) passed.

---
*PR created automatically by Jules for task [7771789082079754377](https://jules.google.com/task/7771789082079754377) started by @hachian*