### PR TITLE
🧹 Refactor related-posts utility to use shared removeDatePrefix

### DIFF
--- a/src/utils/related-posts/index.ts
+++ b/src/utils/related-posts/index.ts
@@ -3,6 +3,7 @@
  * タグベースで関連記事をスコアリングして取得する
  */
 import type { CollectionEntry } from 'astro:content';
+import { removeDatePrefix } from '../../plugins/utils/index.js';
 
 /**
  * 関連記事の型定義
@@ -48,9 +49,6 @@ export function getRelatedPosts(options: GetRelatedPostsOptions): RelatedPost[] 
   if (!currentTags || currentTags.length === 0) {
     return [];
   }
-
-  // YYYYMMDD-プレフィックスを除去するヘルパー
-  const removeDatePrefix = (id: string): string => id.replace(/^\d{8}-/, '');
 
   // 現在のタグをSetに変換（高速な検索のため）
   const currentTagSet = new Set(currentTags);

--- a/src/utils/related-posts/related-posts.test.ts
+++ b/src/utils/related-posts/related-posts.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { getRelatedPosts } from './index.js';
+import { getRelatedPosts } from './index.ts';
 import type { CollectionEntry } from 'astro:content';
 
 // テスト用のモックデータ型

--- a/tests/test-runner.js
+++ b/tests/test-runner.js
@@ -55,6 +55,12 @@ const testSuites = [
     timeout: 30000
   },
   {
+    name: 'Related Posts Unit Tests',
+    command: 'node',
+    args: ['--experimental-transform-types', '--test', 'src/utils/related-posts/related-posts.test.ts'],
+    timeout: 30000
+  },
+  {
     name: 'Callout Unit Tests',
     command: 'node',
     args: ['--test', 'tests/unit/callout-test.js'],


### PR DESCRIPTION
This PR refactors the `related-posts` utility to eliminate duplicated logic for removing date prefixes from slugs. 
It now imports `removeDatePrefix` from the shared `src/plugins/utils/index.js` utility, improving maintainability and consistency.
Additionally, the associated unit test suite (`src/utils/related-posts/related-posts.test.ts`) has been fixed to run correctly with the project's test runner and has been added to the automated test suite configuration.
Verified that all tests pass.

---
*PR created automatically by Jules for task [1096183804760557108](https://jules.google.com/task/1096183804760557108) started by @hachian*