### PR TITLE
🧹 Deduplicate removeDatePrefix in blog slug generation

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,13 +1,9 @@
 ---
 import { type CollectionEntry, getCollection, render } from 'astro:content';
 import BlogPost from '../../layouts/BlogPost.astro';
+import { removeDatePrefix } from '../../plugins/utils/index.js';
 
 export async function getStaticPaths() {
-	// YYYYMMDD-プレフィックスを除去してslugを生成
-	const removeDatePrefix = (id: string): string => {
-		return id.replace(/^\d{8}-/, '');
-	};
-
 	const posts = await getCollection('blog', ({ data }) => {
 		// 本番環境ではdraft: trueの記事を除外
 		return import.meta.env.PROD ? data.draft !== true : true;


### PR DESCRIPTION
Refactored `src/pages/blog/[...slug].astro` to use the shared `removeDatePrefix` utility from `src/plugins/utils/index.js` instead of a local definition. This improves code maintainability and reduces duplication.

🎯 **What:** Replaced local `removeDatePrefix` with imported version.
💡 **Why:** To improve maintainability and reduce code duplication as per code health task.
✅ **Verification:** Verified by creating a test script for the utility and running a full `npm run build` (with a dummy `.env` file) which confirmed that blog posts are generated with correct slugs.
✨ **Result:** Cleaner code in `src/pages/blog/[...slug].astro` with no change in functionality.

---
*PR created automatically by Jules for task [3686980014428595115](https://jules.google.com/task/3686980014428595115) started by @hachian*