### PR TITLE
Refactor: Remove duplicate removeDatePrefix utility

### DIFF
--- a/src/utils/related-posts/index.ts
+++ b/src/utils/related-posts/index.ts
@@ -3,6 +3,7 @@
  * タグベースで関連記事をスコアリングして取得する
  */
 import type { CollectionEntry } from 'astro:content';
+import { removeDatePrefix } from '../../plugins/utils/index.js';
 
 /**
  * 関連記事の型定義
@@ -48,9 +49,6 @@ export function getRelatedPosts(options: GetRelatedPostsOptions): RelatedPost[] 
   if (!currentTags || currentTags.length === 0) {
     return [];
   }
-
-  // YYYYMMDD-プレフィックスを除去するヘルパー
-  const removeDatePrefix = (id: string): string => id.replace(/^\d{8}-/, '');
 
   // 現在のタグをSetに変換（高速な検索のため）
   const currentTagSet = new Set(currentTags);

--- a/src/utils/related-posts/related-posts.test.ts
+++ b/src/utils/related-posts/related-posts.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert';
-import { getRelatedPosts } from './index.js';
+import { getRelatedPosts } from './index.ts';
 import type { CollectionEntry } from 'astro:content';
 
 // テスト用のモックデータ型

--- a/tests/test-runner.js
+++ b/tests/test-runner.js
@@ -66,6 +66,12 @@ const testSuites = [
     args: ['--experimental-transform-types', '--test', 'tests/unit/toc-unit-test.ts'],
     timeout: 30000
   },
+  {
+    name: 'Related Posts Unit Tests',
+    command: 'node',
+    args: ['--experimental-transform-types', '--test', 'src/utils/related-posts/related-posts.test.ts'],
+    timeout: 30000
+  },
   // Integration Tests
   {
     name: 'Integration Tests',


### PR DESCRIPTION
This PR removes a duplicate utility function `removeDatePrefix` from `src/utils/related-posts/index.ts` and replaces it with the shared implementation from `src/plugins/utils/index.js`. 

It also updates `src/utils/related-posts/related-posts.test.ts` to be compatible with the project's test runner (using `.ts` imports) and registers the test suite in `tests/test-runner.js` so it is executed during test runs.

Verification:
- Ran `node tests/test-runner.js` and confirmed that `Related Posts Unit Tests` passed.

---
*PR created automatically by Jules for task [12888583592392762108](https://jules.google.com/task/12888583592392762108) started by @hachian*