### PR TITLE
Refactor tag utils to share escapeRegExp helper

### DIFF
--- a/src/utils/tag/hierarchy.ts
+++ b/src/utils/tag/hierarchy.ts
@@ -5,6 +5,7 @@
 import type { Tag, TagHierarchy, TagOptions } from '../../types/tag';
 import { DEFAULT_TAG_OPTIONS } from '../../types/tag';
 import { normalizeTag, parseTagHierarchy } from './validation';
+import { escapeRegExp } from './utils';
 
 /**
  * タグの配列から階層構造を構築する
@@ -266,11 +267,4 @@ export function hasCircularReference(
   }
   
   return checkNode(hierarchy, path);
-}
-
-/**
- * 正規表現の特殊文字をエスケープ
- */
-function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/utils/tag/utils.ts
+++ b/src/utils/tag/utils.ts
@@ -1,0 +1,6 @@
+/**
+ * 正規表現の特殊文字をエスケープ
+ */
+export function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/utils/tag/validation.ts
+++ b/src/utils/tag/validation.ts
@@ -4,6 +4,7 @@
 
 import type { TagOptions, TagValidationResult, TagErrorCode } from '../../types/tag';
 import { DEFAULT_TAG_OPTIONS } from '../../types/tag';
+import { escapeRegExp } from './utils';
 
 /**
  * タグ名の有効な文字パターン
@@ -229,11 +230,4 @@ export function isDescendantTag(
   const normalizedParent = normalizeTag(parentTag, opts);
   
   return normalizedChild.startsWith(normalizedParent + opts.hierarchySeparator);
-}
-
-/**
- * 正規表現の特殊文字をエスケープする
- */
-function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }


### PR DESCRIPTION
Extracted `escapeRegExp` helper function from `src/utils/tag/hierarchy.ts` and `src/utils/tag/validation.ts` to a new shared utility file `src/utils/tag/utils.ts`. This eliminates code duplication. Verified the refactoring with unit tests and by running the full build process.

---
*PR created automatically by Jules for task [16949152547298329949](https://jules.google.com/task/16949152547298329949) started by @hachian*