### PR TITLE
Refactor: Extract escapeRegExp to shared utility file

### DIFF
--- a/src/utils/tag/hierarchy.ts
+++ b/src/utils/tag/hierarchy.ts
@@ -2,9 +2,10 @@
  * タグの階層構造処理ユーティリティ
  */
 
-import type { Tag, TagHierarchy, TagOptions } from '../../types/tag';
-import { DEFAULT_TAG_OPTIONS } from '../../types/tag';
-import { normalizeTag, parseTagHierarchy } from './validation';
+import type { Tag, TagHierarchy, TagOptions } from '../../types/tag.ts';
+import { DEFAULT_TAG_OPTIONS } from '../../types/tag.ts';
+import { normalizeTag, parseTagHierarchy } from './validation.ts';
+import { escapeRegExp } from './utils.ts';
 
 /**
  * タグの配列から階層構造を構築する
@@ -266,11 +267,4 @@ export function hasCircularReference(
   }
   
   return checkNode(hierarchy, path);
-}
-
-/**
- * 正規表現の特殊文字をエスケープ
- */
-function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/utils/tag/utils.ts
+++ b/src/utils/tag/utils.ts
@@ -1,0 +1,10 @@
+/**
+ * タグ関連の共通ユーティリティ
+ */
+
+/**
+ * 正規表現の特殊文字をエスケープする
+ */
+export function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/utils/tag/validation.ts
+++ b/src/utils/tag/validation.ts
@@ -2,8 +2,9 @@
  * タグのバリデーション関連ユーティリティ
  */
 
-import type { TagOptions, TagValidationResult, TagErrorCode } from '../../types/tag';
-import { DEFAULT_TAG_OPTIONS } from '../../types/tag';
+import type { TagOptions, TagValidationResult, TagErrorCode } from '../../types/tag.ts';
+import { DEFAULT_TAG_OPTIONS } from '../../types/tag.ts';
+import { escapeRegExp } from './utils.ts';
 
 /**
  * タグ名の有効な文字パターン
@@ -229,11 +230,4 @@ export function isDescendantTag(
   const normalizedParent = normalizeTag(parentTag, opts);
   
   return normalizedChild.startsWith(normalizedParent + opts.hierarchySeparator);
-}
-
-/**
- * 正規表現の特殊文字をエスケープする
- */
-function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/tests/test-runner.js
+++ b/tests/test-runner.js
@@ -49,6 +49,12 @@ const testSuites = [
     timeout: 30000
   },
   {
+    name: 'Tag Utils Unit Tests',
+    command: 'node',
+    args: ['--experimental-transform-types', '--test', 'tests/unit/tag-utils-test.ts'],
+    timeout: 30000
+  },
+  {
     name: 'Inline Tags Unit Tests',
     command: 'node',
     args: ['--experimental-transform-types', '--test', 'tests/unit/inline-tags-test.js'],

--- a/tests/unit/tag-utils-test.ts
+++ b/tests/unit/tag-utils-test.ts
@@ -1,0 +1,69 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { escapeRegExp } from '../../src/utils/tag/utils.ts';
+import { validateTagName, normalizeTag, tagToSlug } from '../../src/utils/tag/validation.ts';
+import { buildTagHierarchy } from '../../src/utils/tag/hierarchy.ts';
+
+describe('Tag Utils', () => {
+  describe('escapeRegExp', () => {
+    test('should escape special characters', () => {
+      const specialChars = '.*+?^${}()|[]\\';
+      const escaped = escapeRegExp(specialChars);
+      assert.strictEqual(escaped, '\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\');
+    });
+
+    test('should handle string without special characters', () => {
+      const normalString = 'abc123';
+      const escaped = escapeRegExp(normalString);
+      assert.strictEqual(escaped, normalString);
+    });
+  });
+
+  describe('validation (using escapeRegExp)', () => {
+    test('validateTagName should work with default options', () => {
+      const result = validateTagName('test-tag');
+      assert.strictEqual(result.isValid, true);
+      assert.strictEqual(result.normalizedTag, 'test-tag');
+    });
+
+    test('normalizeTag should handle hierarchy separator', () => {
+      const tag = 'parent/child';
+      const normalized = normalizeTag(tag);
+      assert.strictEqual(normalized, 'parent/child');
+    });
+
+    test('normalizeTag should handle duplicate separators', () => {
+      const tag = 'parent//child';
+      const normalized = normalizeTag(tag);
+      assert.strictEqual(normalized, 'parent/child');
+    });
+
+    test('normalizeTag should handle special characters in separator if customized', () => {
+      // Create a custom separator that needs escaping
+      const options = { hierarchySeparator: '.' };
+      const tag = 'parent..child';
+      // normalizeTag uses getSeparatorRegexes -> escapeRegExp
+      const normalized = normalizeTag(tag, options);
+      assert.strictEqual(normalized, 'parent.child');
+    });
+  });
+
+  describe('hierarchy (using escapeRegExp)', () => {
+    test('buildTagHierarchy should construct hierarchy correctly', () => {
+      const tags = ['parent', 'parent/child'];
+      const hierarchy = buildTagHierarchy(tags);
+
+      assert.ok(hierarchy['parent']);
+      assert.ok(hierarchy['parent'].children['parent/child']);
+    });
+
+    test('buildTagHierarchy should handle custom separator needing escaping', () => {
+      const options = { hierarchySeparator: '.' };
+      const tags = ['parent', 'parent.child'];
+      const hierarchy = buildTagHierarchy(tags, options);
+
+      assert.ok(hierarchy['parent']);
+      assert.ok(hierarchy['parent'].children['parent.child']);
+    });
+  });
+});


### PR DESCRIPTION
Extracted the `escapeRegExp` helper function from `src/utils/tag/validation.ts` and `src/utils/tag/hierarchy.ts` to a shared utility file `src/utils/tag/utils.ts`. This removes code duplication and improves maintainability.

Verified by running new unit tests `tests/unit/tag-utils-test.ts`.

Note: Imports in `validation.ts` and `hierarchy.ts` were updated to include `.ts` extensions to support Node.js native ESM execution for tests. This change is compatible with Astro/Vite builds.

---
*PR created automatically by Jules for task [16856779648092866608](https://jules.google.com/task/16856779648092866608) started by @hachian*