### PR TITLE
⚡ Optimize image deletion with parallel execution

### DIFF
--- a/src/integrations/image-hosting/index.js
+++ b/src/integrations/image-hosting/index.js
@@ -251,14 +251,18 @@ async function rewriteHtmlImageUrls(htmlPath, urlMap) {
  * @param {ImageInfo[]} images - 削除する画像のリスト
  */
 export async function deleteImages(images) {
-  for (const image of images) {
-    try {
-      await fs.unlink(image.filePath);
-    } catch (error) {
-      if (error.code !== 'ENOENT') {
-        throw error;
+  const concurrency = 50;
+  for (let i = 0; i < images.length; i += concurrency) {
+    const batch = images.slice(i, i + concurrency);
+    await Promise.all(batch.map(async (image) => {
+      try {
+        await fs.unlink(image.filePath);
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
       }
-    }
+    }));
   }
 }
 

--- a/tests/performance/delete-images-bench.js
+++ b/tests/performance/delete-images-bench.js
@@ -1,0 +1,67 @@
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { deleteImages } from '../../src/integrations/image-hosting/index.js';
+
+async function benchmark() {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'delete-bench-'));
+  const fileCount = 1000;
+
+  console.log(`Preparing ${fileCount} files for benchmark...`);
+
+  // Create files for baseline
+  const baselineFiles = [];
+  const baselineDir = path.join(tempDir, 'baseline');
+  await fs.mkdir(baselineDir);
+  for (let i = 0; i < fileCount; i++) {
+    const filePath = path.join(baselineDir, `img-${i}.png`);
+    await fs.writeFile(filePath, 'data');
+    baselineFiles.push({ filePath });
+  }
+
+  // Create files for optimized
+  const optimizedFiles = [];
+  const optimizedDir = path.join(tempDir, 'optimized');
+  await fs.mkdir(optimizedDir);
+  for (let i = 0; i < fileCount; i++) {
+    const filePath = path.join(optimizedDir, `img-${i}.png`);
+    await fs.writeFile(filePath, 'data');
+    optimizedFiles.push({ filePath });
+  }
+
+  // Sequential implementation for baseline
+  const sequentialDeleteImages = async (images) => {
+    for (const image of images) {
+      try {
+        await fs.unlink(image.filePath);
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
+      }
+    }
+  };
+
+  console.log('Running baseline (sequential)...');
+  const startBaseline = performance.now();
+  await sequentialDeleteImages(baselineFiles);
+  const endBaseline = performance.now();
+  const baselineTime = endBaseline - startBaseline;
+  console.log(`Baseline time: ${baselineTime.toFixed(2)}ms`);
+
+  console.log('Running optimized (parallel)...');
+  const startOptimized = performance.now();
+  await deleteImages(optimizedFiles);
+  const endOptimized = performance.now();
+  const optimizedTime = endOptimized - startOptimized;
+  console.log(`Optimized time: ${optimizedTime.toFixed(2)}ms`);
+
+  const improvement = ((baselineTime - optimizedTime) / baselineTime) * 100;
+  console.log(`Improvement: ${improvement.toFixed(2)}%`);
+
+  // Cleanup
+  await fs.rm(tempDir, { recursive: true, force: true });
+}
+
+benchmark().catch(console.error);

--- a/tests/unit/astro-image-hosting-test.js
+++ b/tests/unit/astro-image-hosting-test.js
@@ -109,7 +109,7 @@ describe('astroImageHosting', () => {
       // 各画像にfilePath情報があることを確認
       for (const image of images) {
         assert.ok(image.filePath);
-        assert.ok(image.slug);
+        assert.ok(image.key);
         assert.ok(image.fileName);
       }
     });


### PR DESCRIPTION
💡 **What:**
- Optimized `deleteImages` in `src/integrations/image-hosting/index.js` to delete files in parallel using `Promise.all`.
- Implemented a concurrency limit of 50 to avoid potential `EMFILE` errors with large numbers of files.
- Fixed an existing test failure in `tests/unit/astro-image-hosting-test.js` where it was asserting on a non-existent `slug` property (replaced with `key`).
- Added a benchmark script `tests/performance/delete-images-bench.js` to measure the improvement.

🎯 **Why:**
- Sequential deletion of many files is slow due to I/O latency.
- Parallel deletion significantly reduces the total time required for cleanup tasks.

📊 **Measured Improvement:**
- **Baseline (Sequential):** ~127ms for 1000 files.
- **Optimized (Parallel, concurrency=50):** ~26ms for 1000 files.
- **Improvement:** ~80% reduction in execution time.


---
*PR created automatically by Jules for task [15909367517773521445](https://jules.google.com/task/15909367517773521445) started by @hachian*