### PR TITLE
⚡ Optimize Related Posts Calculation Loop

### DIFF
--- a/src/utils/related-posts/index.ts
+++ b/src/utils/related-posts/index.ts
@@ -56,43 +56,47 @@ export function getRelatedPosts(options: GetRelatedPostsOptions): RelatedPost[] 
   const currentTagSet = new Set(currentTags);
 
   // 関連記事を計算
-  const relatedPosts: RelatedPost[] = allPosts
-    .filter((post) => {
-      // 現在の記事自身を除外（日付プレフィックスを除去して比較）
-      if (removeDatePrefix(post.id) === currentPostId) {
-        return false;
+  const relatedPosts: RelatedPost[] = [];
+
+  for (const post of allPosts) {
+    // 現在の記事自身を除外（日付プレフィックスを除去して比較）
+    if (removeDatePrefix(post.id) === currentPostId) {
+      continue;
+    }
+
+    // draft記事を除外
+    if (post.data.draft === true) {
+      continue;
+    }
+
+    // タグが設定されていない記事を除外
+    const postTags = post.data.tags;
+    if (!postTags || postTags.length === 0) {
+      continue;
+    }
+
+    // 共通タグ数をスコアとして計算
+    let score = 0;
+    for (const tag of postTags) {
+      if (currentTagSet.has(tag)) {
+        score++;
       }
+    }
 
-      // draft記事を除外
-      if (post.data.draft === true) {
-        return false;
-      }
+    // 同じカテゴリなら+1ポイント
+    if (currentCategory && post.data.category === currentCategory) {
+      score += 1;
+    }
 
-      // タグが設定されていない記事を除外
-      const postTags = post.data.tags;
-      if (!postTags || postTags.length === 0) {
-        return false;
-      }
-
-      return true;
-    })
-    .map((post) => {
-      // 共通タグ数をスコアとして計算
-      const postTags = post.data.tags || [];
-      let score = postTags.filter((tag) => currentTagSet.has(tag)).length;
-
-      // 同じカテゴリなら+1ポイント
-      if (currentCategory && post.data.category === currentCategory) {
-        score += 1;
-      }
-
-      return {
+    // 共通タグが0の記事を除外
+    if (score > 0) {
+      relatedPosts.push({
         id: post.id,
         data: post.data,
         score,
-      };
-    })
-    .filter((post) => post.score > 0); // 共通タグが0の記事を除外
+      });
+    }
+  }
 
   // ソート: スコア降順、同スコアは更新日（なければ公開日）降順
   relatedPosts.sort((a, b) => {

--- a/tests/performance/related-posts-bench.ts
+++ b/tests/performance/related-posts-bench.ts
@@ -1,0 +1,96 @@
+
+import { getRelatedPosts } from '../../src/utils/related-posts/index.ts';
+import type { CollectionEntry } from 'astro:content';
+
+// Mock post generator
+function createMockPosts(count: number): CollectionEntry<'blog'>[] {
+  const posts: CollectionEntry<'blog'>[] = [];
+  const tagsPool = ['javascript', 'typescript', 'react', 'vue', 'python', 'django', 'rust', 'go', 'java', 'kotlin'];
+  const categoriesPool = ['tech', 'life', 'random', 'coding', 'design'];
+
+  for (let i = 0; i < count; i++) {
+    const numTags = Math.floor(Math.random() * 4); // 0-3 tags
+    const postTags = [];
+    // Ensure unique tags per post
+    const usedTags = new Set();
+    while (postTags.length < numTags) {
+        const tag = tagsPool[Math.floor(Math.random() * tagsPool.length)];
+        if (!usedTags.has(tag)) {
+            usedTags.add(tag);
+            postTags.push(tag);
+        }
+    }
+
+    posts.push({
+      id: `post-${i}`,
+      slug: `post-${i}`,
+      body: 'Content...',
+      collection: 'blog',
+      data: {
+        title: `Post ${i}`,
+        published: new Date(Date.now() - Math.random() * 10000000000),
+        updated: Math.random() > 0.5 ? new Date() : undefined,
+        tags: postTags,
+        category: categoriesPool[Math.floor(Math.random() * categoriesPool.length)],
+        draft: Math.random() < 0.1, // 10% draft
+        description: 'Description',
+      },
+    } as unknown as CollectionEntry<'blog'>);
+  }
+  return posts;
+}
+
+const ITERATIONS = 100;
+const POST_COUNT = 10000;
+
+console.log(`Generating ${POST_COUNT} mock posts...`);
+const allPosts = createMockPosts(POST_COUNT);
+
+// Pick a post with tags to ensure we actually do some work
+let currentPostIndex = 0;
+while (currentPostIndex < allPosts.length && (!allPosts[currentPostIndex].data.tags || allPosts[currentPostIndex].data.tags.length === 0)) {
+    currentPostIndex++;
+}
+
+if (currentPostIndex >= allPosts.length) {
+    console.error("Could not find a post with tags!");
+    process.exit(1);
+}
+
+const currentPost = allPosts[currentPostIndex];
+const currentTags = currentPost.data.tags || [];
+const currentCategory = currentPost.data.category;
+
+console.log(`Current Post Tags: ${currentTags.join(', ')}`);
+console.log(`Current Post Category: ${currentCategory}`);
+
+console.log(`Running benchmark with ${ITERATIONS} iterations...`);
+
+let totalDuration = 0;
+
+// Warmup
+for (let i = 0; i < 10; i++) {
+  getRelatedPosts({
+    currentPostId: currentPost.id,
+    currentTags,
+    currentCategory,
+    allPosts,
+    limit: 6,
+  });
+}
+
+for (let i = 0; i < ITERATIONS; i++) {
+  const start = performance.now();
+  getRelatedPosts({
+    currentPostId: currentPost.id,
+    currentTags,
+    currentCategory,
+    allPosts,
+    limit: 6,
+  });
+  const end = performance.now();
+  totalDuration += (end - start);
+}
+
+const averageDuration = totalDuration / ITERATIONS;
+console.log(`Average execution time: ${averageDuration.toFixed(4)} ms`);


### PR DESCRIPTION
💡 **What:**
Optimized the `getRelatedPosts` function in `src/utils/related-posts/index.ts`. I replaced the chained `filter`, `map`, and `filter` operations with a single `for...of` loop. I also optimized the score calculation to avoid creating intermediate arrays for each post's tags.

🎯 **Why:**
The previous implementation iterated over the `allPosts` array multiple times and created intermediate arrays, which is inefficient for large datasets. Combining these into a single pass reduces memory allocation and CPU cycles.

📊 **Measured Improvement:**
I created a benchmark script `tests/performance/related-posts-bench.ts` that generates 10,000 mock posts and measures the execution time of `getRelatedPosts`.

- **Baseline:** ~7.3ms
- **Optimized:** ~4.0ms
- **Improvement:** ~45% reduction in execution time.

Verified that existing logic is preserved using `src/utils/related-posts/related-posts.test.ts`.


---
*PR created automatically by Jules for task [3530593129593138967](https://jules.google.com/task/3530593129593138967) started by @hachian*