### PR TITLE
Add empty title validation test for OG image generator

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -4,7 +4,7 @@
  * このファイルでサイト全体の設定を一元管理します。
  * 各設定項目を編集することで、サイトの見た目や動作をカスタマイズできます。
  */
-import type { SiteConfig } from './src/types/site-config';
+import type { SiteConfig } from './src/types/site-config.ts';
 
 /**
  * サイト設定オブジェクト

--- a/src/types/site-config.ts
+++ b/src/types/site-config.ts
@@ -74,7 +74,7 @@ export interface ThemeConfig {
    * - 数値: 0-360（色相値を直接指定）
    * デフォルト: 'purple'（293）
    */
-  primaryHue: import('../theme/color-presets').ThemeColorInput;
+  primaryHue: import('../theme/color-presets.ts').ThemeColorInput;
 }
 
 /**

--- a/src/utils/og-image/compression-config.ts
+++ b/src/utils/og-image/compression-config.ts
@@ -2,7 +2,7 @@
  * OG画像圧縮設定
  * WebP/PNGの圧縮パラメータを管理
  */
-import type { OgImageCompressionConfig, OgImageFormat } from "../../types/site-config";
+import type { OgImageCompressionConfig, OgImageFormat } from "../../types/site-config.ts";
 
 export type { OgImageCompressionConfig, OgImageFormat };
 

--- a/src/utils/og-image/image-generator.test.ts
+++ b/src/utils/og-image/image-generator.test.ts
@@ -10,7 +10,7 @@ import {
   generateDefaultOgImage,
   getOgImageContentType,
   getOgImageFormat,
-} from "./image-generator";
+} from "./image-generator.ts";
 
 describe("OG画像生成", () => {
   describe("getOgImageContentType", () => {
@@ -41,6 +41,36 @@ describe("OG画像生成", () => {
 
       assert.strictEqual(riff, "RIFF", "WebP RIFFヘッダーが存在すること");
       assert.strictEqual(webp, "WEBP", "WebP識別子が存在すること");
+    });
+  });
+
+  describe("generateOgImage - バリデーション", () => {
+    it("タイトルが空の場合はエラーをスローする", async () => {
+      await assert.rejects(
+        async () => {
+          await generateOgImage({
+            title: "",
+            slug: "test-slug",
+          });
+        },
+        {
+          message: "タイトルは空文字列であってはなりません",
+        }
+      );
+    });
+
+    it("タイトルがスペースのみの場合はエラーをスローする", async () => {
+      await assert.rejects(
+        async () => {
+          await generateOgImage({
+            title: "   ",
+            slug: "test-slug",
+          });
+        },
+        {
+          message: "タイトルは空文字列であってはなりません",
+        }
+      );
     });
   });
 

--- a/src/utils/og-image/image-generator.ts
+++ b/src/utils/og-image/image-generator.ts
@@ -2,14 +2,14 @@ import satori from "satori";
 import sharp from "sharp";
 import { readFile } from "fs/promises";
 import { join } from "path";
-import { loadFonts } from "./font-loader";
-import { siteConfig } from "../../../site.config";
+import { loadFonts } from "./font-loader.ts";
+import { siteConfig } from "../../../site.config.ts";
 import {
   getCompressionConfig,
   getOgImageContentType as getContentType,
   getOgImageFormat as getFormat,
   type OgImageFormat,
-} from "./compression-config";
+} from "./compression-config.ts";
 
 // プロジェクトルートからの絶対パスを使用
 const ASSETS_DIR = join(process.cwd(), "src/assets");

--- a/tests/test-runner.js
+++ b/tests/test-runner.js
@@ -66,6 +66,12 @@ const testSuites = [
     args: ['--experimental-transform-types', '--test', 'tests/unit/toc-unit-test.ts'],
     timeout: 30000
   },
+  {
+    name: 'OG Image Generator Tests',
+    command: 'node',
+    args: ['--experimental-transform-types', '--test', 'src/utils/og-image/image-generator.test.ts'],
+    timeout: 30000
+  },
   // Integration Tests
   {
     name: 'Integration Tests',


### PR DESCRIPTION
This PR adds a validation test case for the `generateOgImage` function to ensure it throws an error when the title is empty or contains only whitespace. It also updates import paths to include `.ts` extensions, making the code compatible with Node.js's experimental TypeScript support, and registers the test suite in the custom test runner.

---
*PR created automatically by Jules for task [18380191117369510472](https://jules.google.com/task/18380191117369510472) started by @hachian*