### PR TITLE
🔒 Fix unbounded recursion in remark-callout plugin

### DIFF
--- a/src/plugins/remark-callout/index.js
+++ b/src/plugins/remark-callout/index.js
@@ -1,4 +1,4 @@
-import { visit } from 'unist-util-visit';
+import { visit, SKIP } from 'unist-util-visit';
 
 /**
  * remark-callout - Obsidianスタイルのコールアウト用remarkプラグイン
@@ -222,11 +222,17 @@ function processCallout(node, depth = 0, maxDepth = 3) {
  * @param {number} maxDepth - 最大ネスト深度
  */
 function processNestedCallouts(nodes, depth, maxDepth) {
-  for (const node of nodes) {
+  const stack = [...nodes].reverse();
+
+  while (stack.length > 0) {
+    const node = stack.pop();
+
     if (node.type === 'blockquote' && depth < maxDepth && isCallout(node)) {
       processCallout(node, depth + 1, maxDepth);
     } else if (node.children) {
-      processNestedCallouts(node.children, depth, maxDepth);
+      for (let i = node.children.length - 1; i >= 0; i--) {
+        stack.push(node.children[i]);
+      }
     }
   }
 }
@@ -247,6 +253,8 @@ export default function remarkCallout(options = {}) {
 
       // コールアウトを処理（データを追加、構造は変換しない）
       processCallout(node, 0, maxNestingDepth);
+
+      return SKIP;
     });
   };
 }


### PR DESCRIPTION
This PR fixes a security vulnerability (stack overflow) in `remark-callout` plugin caused by recursive processing of deeply nested blockquotes.

**Changes:**
1.  **Iterative Traversal:** `processNestedCallouts` now uses a stack (DFS) to traverse children instead of recursive calls. This allows processing arbitrarily deep structures without consuming call stack frames.
2.  **Skip Visitor Traversal:** The main `visit` callback now returns `SKIP` when a callout is processed. Since `processCallout` (and its helper `processNestedCallouts`) handles the entire subtree of the callout, allowing `unist-util-visit` to continue traversing children would be redundant and, more importantly, would cause stack overflow in `unist-util-visit` itself for deep trees.

**Verification:**
-   Created a reproduction script generating 20,000 nested blockquotes inside a callout.
-   Confirmed that the original code crashed with `RangeError: Maximum call stack size exceeded`.
-   Confirmed that the patched code processes the same input successfully.
-   Ran existing `tests/unit/callout-test.js` to ensure all standard callout features (nesting, folding, aliases, etc.) work as expected.

---
*PR created automatically by Jules for task [5230862922109132783](https://jules.google.com/task/5230862922109132783) started by @hachian*